### PR TITLE
Link directly to a translation using ?lang=_

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,23 +12,6 @@
   ga('send', 'pageview');
 
 </script>
-<script type="text/javascript">
-
-/** Toggle function to show or hide a div
-* @parameter anId string is of the element to show or hide
-*/
-function toggle(contentId) {
-	var contents = Array.prototype.slice.call(document.querySelectorAll('#contents > div'));
-	contents.map(function (c) {
-		c.style.visibility = "hidden"
-		c.style.display = 'none'
-		c.style.height = '0px'
-	})
-	document.getElementById(contentId).style.visibility = 'visible'
-	document.getElementById(contentId).style.display = 'block'
-	document.getElementById(contentId).style.height = 'auto'
-}
-</script>
 
 <script type="text/javascript">var switchTo5x=true;</script>
 <script type="text/javascript" src="https://ws.sharethis.com/button/buttons.js"></script>
@@ -288,5 +271,35 @@ to withstand turbulent conditions in production.</span></h3>
 <span class='st_email_hcount' displayText='Email'></span>
 </p>
 </div>
+
+<script type="text/javascript">
+
+/** Toggle function to show or hide a div
+* @parameter anId string is of the element to show or hide
+*/
+function toggle(contentId) {
+	var contents = Array.prototype.slice.call(document.querySelectorAll('#contents > div'));
+	contents.map(function (c) {
+		c.style.visibility = "hidden"
+		c.style.display = 'none'
+		c.style.height = '0px'
+	})
+	document.getElementById(contentId).style.visibility = 'visible'
+	document.getElementById(contentId).style.display = 'block'
+	document.getElementById(contentId).style.height = 'auto'
+}
+
+/* link directly to a language in the url: ?lang=FRcontent */
+if (window.location.search && window.location.search.indexOf('lang=') > -1) {
+	var language = window.location.search.split('lang=')[1];
+	if (language.indexOf('&') > -1) {
+		language = language.split('&')[0];
+	}
+	if (document.getElementById(language)) {
+		toggle(language);
+	}
+}
+</script>
+
 </body>
 </html>


### PR DESCRIPTION
This would allow someone to link the language-specific page using links such as

http://principlesofchaos.org/?lang=FRcontent

The code for this change needs to be at the end of the document so that it can detect whether the selected language exists or not (for example, a link with lang=xyz should not break the page)

I thought it would be prudent to move the ```toggle``` function to the end, too, so that all related code would be in the same script block.  If this is unwanted, I could change the PR to keep it in place and add only the new code at the end.

Edit: oh, I see a few translations are hosted by other users. hmmm