### PR TITLE
Append `?lang=` query when calling `toggle()`

### DIFF
--- a/index.html
+++ b/index.html
@@ -513,13 +513,15 @@ to withstand turbulent conditions in production.</span></h3>
     function toggle(contentId) {
         var contents = Array.prototype.slice.call(document.querySelectorAll('#contents > div'));
         contents.map(function (c) {
-            c.style.visibility = "hidden"
-            c.style.display = 'none'
-            c.style.height = '0px'
-        })
-        document.getElementById(contentId).style.visibility = 'visible'
-        document.getElementById(contentId).style.display = 'block'
-        document.getElementById(contentId).style.height = 'auto'
+            c.style.visibility = "hidden";
+            c.style.display = 'none';
+            c.style.height = '0px';
+        });
+        document.getElementById(contentId).style.visibility = 'visible';
+        document.getElementById(contentId).style.display = 'block';
+        document.getElementById(contentId).style.height = 'auto';
+
+        window.history.replaceState({}, '', '?lang=' + contentId);
     }
 
     /* link directly to a language in the url: ?lang=FRcontent */


### PR DESCRIPTION
## What
This PR append a `?lang=` query parameter when calling `toggle()`.

For example, when we click `日本語`(Japanese) link, the location change from 
`https://principlesofchaos.org/` to `https://principlesofchaos.org/?lang=JAcontent#`.

## Why
Formally, when we click the link for localized page at the bottom, the URL didn't change. This PR enables a user to share URL of a localized page.